### PR TITLE
Fix license seperator dedection

### DIFF
--- a/cmd/notice-file-generator/notice.go
+++ b/cmd/notice-file-generator/notice.go
@@ -100,7 +100,7 @@ func SplitExistingNotice(config *Config) error {
 				writer = bufio.NewWriter(out)
 			}
 			if out != nil {
-				if strings.HasPrefix(line, "---") {
+				if line == "---" {
 					writer.Flush()
 					out.Close()
 					writer = nil


### PR DESCRIPTION
#### Summary
This PR contains changes to fix licence separator in existing Notice.txt file. Cause of `hasPrefix` usage, application may use different separator to split licences.

Application should check exact match of `---` instead of `hasPrefix`.

Please see https://github.com/mattermost/mattermost-webapp/pull/10597 for the generated output.

#### Ticket Link
Fixes https://github.com/mattermost/notice-file-generator/issues/5