### PR TITLE
Enable Python Pipfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # notice-file-generator
-Notice file generator Mattermost tool to automatically generate NOTICE file for Go and Node projects.
+Notice file generator Mattermost tool to automatically generate NOTICE file for Go, Node and Python projects.
 
 ## Get Involved
 

--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -43,6 +43,22 @@ func (c *Config) NoticeWorkPath() string {
 func (c *Config) NoticeFilePath() string {
 	return fmt.Sprintf("%s/NOTICE.txt", c.Path)
 }
+func (c *Config) determineRepoType() {
+	for _, search := range c.Search {
+		if strings.Contains(search, "package.json") {
+			c.RepoType = JsRepo
+			break
+		}
+		if strings.Contains(search, "go.mod") {
+			c.RepoType = GoRepo
+			break
+		}
+		if strings.Contains(search, "Pipfile") {
+			c.RepoType = PythonRepo
+			break
+		}
+	}
+}
 
 func newConfig() *Config {
 	repositoryPath := flag.String("p", "", "Repository Path")
@@ -70,22 +86,7 @@ func newConfig() *Config {
 	if err = yaml.Unmarshal(content, config); err != nil {
 		log.Fatalf("%s - Configuration file error! %v", *repositoryPath, err)
 	}
-
-	for _, search := range config.Search {
-		if strings.Contains(search, "package.json") {
-			config.RepoType = JsRepo
-			break
-		}
-		if strings.Contains(search, "go.mod") {
-			config.RepoType = GoRepo
-			break
-		}
-		if strings.Contains(search, "Pipfile") {
-			config.RepoType = PythonRepo
-			break
-		}
-	}
-
+	config.determineRepoType()
 	return config
 
 }

--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -10,6 +10,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type RepoType int
+
+const (
+	JsRepo RepoType = iota
+	GoRepo
+	PythonRepo
+)
+
 type Config struct {
 	Title           string   `yaml:"title"`
 	Copyright       string   `yaml:"copyright"`
@@ -21,6 +29,7 @@ type Config struct {
 	Name            string   `yaml:"-"`
 	Path            string   `yaml:"-"`
 	GHToken         string   `yaml:"-"`
+	RepoType        RepoType `yaml:"-"`
 }
 
 func (c *Config) NoticeDirPath() string {
@@ -33,36 +42,6 @@ func (c *Config) NoticeWorkPath() string {
 
 func (c *Config) NoticeFilePath() string {
 	return fmt.Sprintf("%s/NOTICE.txt", c.Path)
-}
-
-func (c *Config) IsJsRepo() bool {
-	for _, search := range c.Search {
-		if strings.Contains(search, "package.json") {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (c *Config) IsGoRepo() bool {
-	for _, search := range c.Search {
-		if strings.Contains(search, "go.mod") {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (c *Config) IsPythonRepo() bool {
-	for _, search := range c.Search {
-		if strings.Contains(search, "Pipfile") {
-			return true
-		}
-	}
-
-	return false
 }
 
 func newConfig() *Config {
@@ -90,6 +69,21 @@ func newConfig() *Config {
 	}
 	if err = yaml.Unmarshal(content, config); err != nil {
 		log.Fatalf("%s - Configuration file error! %v", *repositoryPath, err)
+	}
+
+	for _, search := range config.Search {
+		if strings.Contains(search, "package.json") {
+			config.RepoType = JsRepo
+			break
+		}
+		if strings.Contains(search, "go.mod") {
+			config.RepoType = GoRepo
+			break
+		}
+		if strings.Contains(search, "Pipfile") {
+			config.RepoType = PythonRepo
+			break
+		}
 	}
 
 	return config

--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -55,6 +55,16 @@ func (c *Config) IsGoRepo() bool {
 	return false
 }
 
+func (c *Config) IsPythonRepo() bool {
+	for _, search := range c.Search {
+		if strings.Contains(search, "Pipfile") {
+			return true
+		}
+	}
+
+	return false
+}
+
 func newConfig() *Config {
 	repositoryPath := flag.String("p", "", "Repository Path")
 	repositoryName := flag.String("n", "", "Name of the Repo")

--- a/cmd/notice-file-generator/config_test.go
+++ b/cmd/notice-file-generator/config_test.go
@@ -25,6 +25,9 @@ func TestRepoType(t *testing.T) {
 	jsconfig := Config{Search: []string{"", "package.json"}}
 	goconfig := Config{Search: []string{"", "go.mod"}}
 	pythonconfig := Config{Search: []string{"", "Pipfile"}}
+	jsconfig.determineRepoType()
+	goconfig.determineRepoType()
+	pythonconfig.determineRepoType()
 	assert.Equal(t, JsRepo, jsconfig.RepoType)
 	assert.Equal(t, GoRepo, goconfig.RepoType)
 	assert.Equal(t, PythonRepo, pythonconfig.RepoType)

--- a/cmd/notice-file-generator/config_test.go
+++ b/cmd/notice-file-generator/config_test.go
@@ -21,11 +21,13 @@ func TestNoticeFilePath(t *testing.T) {
 	config := Config{Path: "/tmp/work"}
 	assert.Equal(t, "/tmp/work/NOTICE.txt", config.NoticeFilePath())
 }
-func TestIsJsRepo(t *testing.T) {
+func TestRepoType(t *testing.T) {
 	jsconfig := Config{Search: []string{"", "package.json"}}
 	goconfig := Config{Search: []string{"", "go.mod"}}
-	assert.True(t, jsconfig.IsJsRepo())
-	assert.False(t, goconfig.IsJsRepo())
+	pythonconfig := Config{Search: []string{"", "Pipfile"}}
+	assert.Equal(t, JsRepo, jsconfig.RepoType)
+	assert.Equal(t, GoRepo, goconfig.RepoType)
+	assert.Equal(t, PythonRepo, pythonconfig.RepoType)
 }
 
 func TestNewConfig(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR contains changes to support Python Pipfile. It is not possible to determine url by using `source.url` cause it only store the dependency archive and provide no metadata about the package. For that reason developers need to define github repositories in the Pipfile. Similar to below:
```
#
# Amazon AWS Universal CLI environment (https://aws.amazon.com/cli/)
# Release notes: https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst
# Repo: https://github.com/aws/aws-cli
awscli = "==1.20
```

Only Github repositories are supported atm. Github was also used for Go dependency. So to support Python we only need to populate repo url from Pipfile and existing code will handle the rest.
 
#### Ticket Link
Fixes https://github.com/mattermost/notice-file-generator/issues/4
