### PR TITLE
[feat] Make GitHub PAT optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist/
 # Intermediate folders
 -notice
 -notice-work
+.-notice/
 
 # Critical files
 *.key

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Arguments:
 | :--  | :--      | :---------- |
 | Configuration File | -c <path_to_config_file> | Full path of the configuration file. |
 | Name | -n <project_name> | Name of the project, tool will create temporary folders by using project name.
-| Proejct Path | -p <project_path> | Full path of the project's root directory |
-| Github Token | -t <github_pat_token> | Dependency licences will be fetched from Github, token needed to remove API rate limits. |
+| Project Path | -p <project_path> | Full path of the project's root directory |
+| Github Token (optional) | -t <github_pat_token> | Dependency licences will be fetched from Github, token needed to remove API rate limits. |
 
 ### Testing
 

--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -68,7 +68,7 @@ func newConfig() *Config {
 
 	flag.Parse()
 
-	if len(*repositoryPath) == 0 || len(*repositoryName) == 0 || len(*githubToken) == 0 || len(*configFilePath) == 0 {
+	if len(*repositoryPath) == 0 || len(*repositoryName) == 0 || len(*configFilePath) == 0 {
 		fmt.Println("Usage: main.go -n name -p path -t token -c configFile")
 		flag.PrintDefaults()
 		os.Exit(1)

--- a/cmd/notice-file-generator/dependency.go
+++ b/cmd/notice-file-generator/dependency.go
@@ -105,16 +105,19 @@ func (d *Dependency) NpmLoad() error {
 
 func (d *Dependency) LoadFromGithub(config *Config) error {
 	if strings.Contains(d.Repository.URL, "github.com") {
+		var gh = github.NewClient(nil)
 		repoDef := strings.Split(d.Repository.URL, "/")
 		scope := repoDef[len(repoDef)-2]
 		repoName := strings.ReplaceAll(repoDef[len(repoDef)-1], ".git", "")
 
-		ctx := context.Background()
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: config.GHToken},
-		)
-		tc := oauth2.NewClient(ctx, ts)
-		gh := github.NewClient(tc)
+		if len(config.GHToken) != 0 {
+			ctx := context.Background()
+			ts := oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: config.GHToken},
+			)
+			tc := oauth2.NewClient(ctx, ts)
+			gh = github.NewClient(tc)
+		}
 
 		repo, _, err := gh.Repositories.Get(context.Background(), scope, repoName)
 		if err != nil {


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We can offer the functionality, to not declare a Github PAT.
If that is the case, we acknowledge rate limiting applied.

```
For unauthenticated requests, the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the person making requests.
```
https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-personal-accounts

Signed-off-by: Akis Maziotis <akis.maziotis@mattermost.com>


