### PR TITLE
Add support for additionalDependencies field

### DIFF
--- a/.config/notice-file/Readme.md
+++ b/.config/notice-file/Readme.md
@@ -13,8 +13,8 @@ copyright: "©2022 Mattermost, Inc.  All Rights Reserved.  See LICENSE.txt for l
 description: "This document includes a list of open source components used in Mattermost Motice File Generator, including those that have been modified."
 search:
   - "go.mod"
-dependencies: []
-devDependencies: []
+additionalDependencies:
+  - wix
 ```
 
 | Field                  | Type    | Purpose                                                                                                                  |
@@ -23,4 +23,5 @@ devDependencies: []
 | copyright              | string  | Field content will be used as a copyright message. See second line of `NOTICE.txt` file.                                 |
 | description            | string  | Field content will be used as notice file description. See third line of `NOTICE.txt` file.                              |
 | includeDevDependencies | boolean | If true we include devDependency section of all package.json files declared.                                             |
+| additionalDependencies | array   | Optional additional dependencies. Their stanzas in the `NOTICE.txt` file should be added manually.                       |
 | search                 | array   | Pipeline will search for package.json files mentioned here. Globstar format is supported ie. `packages/**/package.json`. |

--- a/.config/notice-file/config.yaml
+++ b/.config/notice-file/config.yaml
@@ -4,4 +4,6 @@ copyright: "©2022 Mattermost, Inc.  All Rights Reserved.  See LICENSE.txt for l
 description: "This document includes a list of open source components used in Mattermost Motice File Generator, including those that have been modified."
 search:
   - "go.mod"
+additionalDependencies:
+  - wix
 includeDevDependencies: false

--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Reviewers              []string `yaml:"reviewers"`
 	Search                 []string `yaml:"search"`
 	IncludeDevDependencies bool     `yaml:"includeDevDependencies"`
+	AdditionalDependencies []string `yaml:"additionalDependencies"`
 	Name                   string   `yaml:"-"`
 	Path                   string   `yaml:"-"`
 	GHToken                string   `yaml:"-"`

--- a/cmd/notice-file-generator/config_test.go
+++ b/cmd/notice-file-generator/config_test.go
@@ -47,4 +47,6 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, "reviewerOne", config.Reviewers[0])
 	assert.Equal(t, 1, len(config.Search))
 	assert.Equal(t, "package.json", config.Search[0])
+	assert.Equal(t, 1, len(config.AdditionalDependencies))
+	assert.Equal(t, "wix", config.AdditionalDependencies[0])
 }

--- a/cmd/notice-file-generator/dependency.go
+++ b/cmd/notice-file-generator/dependency.go
@@ -19,7 +19,9 @@ import (
 type DependencyType int
 
 const (
-	JsDep DependencyType = iota
+	// The default DependencyType is unspecified
+	_ DependencyType = iota
+	JsDep
 	GoDep
 )
 
@@ -205,6 +207,8 @@ func (d *Dependency) Generate(config *Config) error {
 				log.Printf("GitHub load failed  %s", d.Name)
 				return err
 			}
+		default:
+			return fmt.Errorf("unsupported dependency type for %s. Please add the notice stanza manually, before running this program", d.Name)
 		}
 
 		var out *os.File
@@ -411,6 +415,8 @@ func PopulateDependencies(config *Config) ([]Dependency, error) {
 		}
 		allDeps = append(allDeps, d...)
 	}
-
+	for _, dep := range config.AdditionalDependencies {
+		allDeps = append(allDeps, Dependency{Name: dep})
+	}
 	return allDeps, nil
 }

--- a/cmd/notice-file-generator/main.go
+++ b/cmd/notice-file-generator/main.go
@@ -79,7 +79,7 @@ func main() {
 			defer wg.Done()
 
 			if err = d.Generate(config); err != nil {
-				log.Printf("Error occured while generating notice.txt %s:%v", d.Name, err)
+				log.Fatalf("Error occured while generating notice.txt %s:%v", d.Name, err)
 			}
 
 		}()

--- a/cmd/notice-file-generator/testdata/test.yaml
+++ b/cmd/notice-file-generator/testdata/test.yaml
@@ -7,9 +7,6 @@ reviewers:
   - reviewerOne
 search:
   - "package.json"
-dependencies:
-  - "wix"
-devDependencies: 
-  - "webpack"
-
+additionalDependencies:
+  - wix
 ...


### PR DESCRIPTION
#### Summary

This PR adds support for the optional `additionalDependencies` field in the notice-file-generator config. this field contains "untyped" dependencies (not known if it's a JS or Go dependency), so that devs can manually add a stanzas to the `NOTICE.txt` file: adding such dependencies to the `additionalDependencies` array prevents them from being deleted by a notice-file-generator run.

This is required for the [desktop repo](https://github.com/mattermost/desktop/blob/master/.config/notice-file/config.yaml), which depends on `wix` but this is not visible in `package.json`.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7792