### PR TITLE
Remove dependency on internal registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ DOCKER_PASSWORD         ?= password
 DOCKER_IMAGE_GO         ?= "golang:1.21.8"
 DOCKER_IMAGE_DOCKERLINT ?= "hadolint/hadolint:v2.9.2@sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b"
 DOCKER_IMAGE_COSIGN     ?= "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"
-DOCKER_IMAGE_GH_CLI     ?= "registry.internal.mattermost.com/images/build-ci:3.16.0@sha256:f6a229a9ababef3c483f237805ee4c3dbfb63f5de4fbbf58f4c4b6ed8fcd34b6"
 
 ## Cosign Variables
 # The public key
@@ -341,13 +340,7 @@ github-release: ## to publish a release and relevant artifacts to GitHub
 ifeq ($(shell echo $(APP_VERSION) | egrep '^v([0-9]+\.){0,2}(\*|[0-9]+)'),)
 	$(error "We only support releases from semver tags")
 else
-	$(AT)$(DOCKER) run \
-	-v $(PWD):/app -w /app \
-	-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-	$(DOCKER_IMAGE_GH_CLI) \
-	/bin/sh -c \
-	"cd /app && \
-	gh release create $(APP_VERSION) --generate-notes $(GO_OUT_BIN_DIR)/*" || ${FAIL}
+	$(AT)gh release create $(APP_VERSION) --generate-notes $(GO_OUT_BIN_DIR)/*" || ${FAIL}
 endif
 	@$(OK) Generating github-release http://github.com/$(GITHUB_ORG)/$(GITHUB_REPO)/releases/tag/$(APP_VERSION) ...
 


### PR DESCRIPTION
#### Summary

Eliminate dependency of the release process on the internal registry. It should be safe to assume that the environment this runs on has the `gh` binary, in addition to docker

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7792