### PR TITLE
Add ignoreDependencies field

### DIFF
--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Search                 []string `yaml:"search"`
 	IncludeDevDependencies bool     `yaml:"includeDevDependencies"`
 	AdditionalDependencies []string `yaml:"additionalDependencies"`
+	IgnoreDependencies     []string `yaml:"ignoreDependencies"`
 	Name                   string   `yaml:"-"`
 	Path                   string   `yaml:"-"`
 	GHToken                string   `yaml:"-"`

--- a/cmd/notice-file-generator/config.go
+++ b/cmd/notice-file-generator/config.go
@@ -27,6 +27,12 @@ type Config struct {
 	JSFIles                []string `yaml:"-"`
 }
 
+type Argument struct {
+	Name         string
+	DefaultValue string
+	Description  string
+}
+
 func (c *Config) NoticeDirPath() string {
 	return fmt.Sprintf("%s/.notice", c.Path)
 }
@@ -55,32 +61,54 @@ func (c *Config) determineRepoFiles() {
 	}
 }
 
-func newConfig() *Config {
-	repositoryPath := flag.String("p", ".", "Repository Path")
-	githubToken := flag.String("t", "", "Github Authentication Token")
-	configFilePath := flag.String("c", "", "Configuration File Path")
+func getArgs() map[string]string {
+	m := make(map[string]string)
+	supportedArguments := []Argument{
+		{"p", ".", "Repository Path"},
+		{"t", "", "Github Authentication Token"},
+		{"c", "", "Configuration File Path"},
+	}
+	flagsDefined := (flag.Lookup(supportedArguments[0].Name) != nil)
 
+	if !flagsDefined {
+		// Define the flags before parsing the CLI args
+		for _, arg := range supportedArguments {
+			_ = flag.String(arg.Name, arg.DefaultValue, arg.Description)
+		}
+	}
+	// The flags are now defined: parse their value, then retrieve it
 	flag.Parse()
+	for _, arg := range supportedArguments {
+		m[arg.Name] = (flag.Lookup(arg.Name).Value.String())
+	}
+	return m
+}
 
-	if len(*configFilePath) == 0 || len(*repositoryPath) == 0 {
+func newConfig() *Config {
+	args := getArgs()
+	repositoryPath := args["p"]
+	githubToken := args["t"]
+	configFilePath := args["c"]
+
+	if len(configFilePath) == 0 || len(repositoryPath) == 0 {
 		fmt.Println("Usage: main.go -p path -t token -c configFile")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	content, err := os.ReadFile(*configFilePath)
+	content, err := os.ReadFile(configFilePath)
 	if err != nil {
-		log.Fatalf("%s - Configuration file error! %v", *repositoryPath, err)
+		log.Fatalf("%s - Configuration file error! %v", repositoryPath, err)
 	}
 	// Path always exist, no need to check error
-	repoFullPath, _ := filepath.Abs(*repositoryPath)
+	repoFullPath, _ := filepath.Abs(repositoryPath)
 	config := &Config{
 		Path:    repoFullPath,
-		GHToken: *githubToken,
+		GHToken: githubToken,
 	}
 
 	if err = yaml.Unmarshal(content, config); err != nil {
-		log.Fatalf("%s - Configuration file error! %v", *repositoryPath, err)
+		log.Fatalf("%s - Configuration file error! %v", repositoryPath, err)
 	}
 
 	config.determineRepoFiles()

--- a/cmd/notice-file-generator/config_test.go
+++ b/cmd/notice-file-generator/config_test.go
@@ -52,4 +52,6 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, "ignored", config.AdditionalDependencies[1])
 	assert.Equal(t, 1, len(config.IgnoreDependencies))
 	assert.Equal(t, "ignored", config.IgnoreDependencies[0])
+
+	os.Args = os.Args[:len(os.Args)-3]
 }

--- a/cmd/notice-file-generator/config_test.go
+++ b/cmd/notice-file-generator/config_test.go
@@ -47,6 +47,9 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, "reviewerOne", config.Reviewers[0])
 	assert.Equal(t, 1, len(config.Search))
 	assert.Equal(t, "package.json", config.Search[0])
-	assert.Equal(t, 1, len(config.AdditionalDependencies))
+	assert.Equal(t, 2, len(config.AdditionalDependencies))
 	assert.Equal(t, "wix", config.AdditionalDependencies[0])
+	assert.Equal(t, "ignored", config.AdditionalDependencies[1])
+	assert.Equal(t, 1, len(config.IgnoreDependencies))
+	assert.Equal(t, "ignored", config.IgnoreDependencies[0])
 }

--- a/cmd/notice-file-generator/dependency.go
+++ b/cmd/notice-file-generator/dependency.go
@@ -397,6 +397,23 @@ func (c *Config) PopulateGoDependencies(goModFile string) ([]Dependency, error) 
 	return goDependencies.value, nil
 }
 
+func RemoveIgnoredDependencies(allDeps []Dependency, depsToIgnore []string) []Dependency {
+	var filteredDeps []Dependency
+	for i := 0; i < len(allDeps); i++ {
+		for _, dep := range depsToIgnore {
+			if allDeps[i].Name == dep {
+				allDeps[i].Name = ""
+			}
+		}
+	}
+	for _, dep := range allDeps {
+		if dep.Name != "" {
+			filteredDeps = append(filteredDeps, dep)
+		}
+	}
+	return filteredDeps
+}
+
 func PopulateDependencies(config *Config) ([]Dependency, error) {
 	var allDeps []Dependency
 
@@ -418,5 +435,6 @@ func PopulateDependencies(config *Config) ([]Dependency, error) {
 	for _, dep := range config.AdditionalDependencies {
 		allDeps = append(allDeps, Dependency{Name: dep})
 	}
+	allDeps = RemoveIgnoredDependencies(allDeps, config.IgnoreDependencies)
 	return allDeps, nil
 }

--- a/cmd/notice-file-generator/dependency_test.go
+++ b/cmd/notice-file-generator/dependency_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +41,14 @@ func TestPopulateLicenseByUrl(t *testing.T) {
 	license := dep.PopulateLicence()
 
 	assert.NotEmpty(t, license)
+}
+
+func TestIgnoreDependencies(t *testing.T) {
+	os.Args = append(os.Args, "-p=/tmp/test", "-t=token", "-c=testdata/dependency_test.yaml")
+
+	config := newConfig()
+	allDeps, err := PopulateDependencies(config)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(allDeps))
+	assert.Equal(t, "wix", allDeps[0].Name)
 }

--- a/cmd/notice-file-generator/dependency_test.go
+++ b/cmd/notice-file-generator/dependency_test.go
@@ -51,4 +51,6 @@ func TestIgnoreDependencies(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(allDeps))
 	assert.Equal(t, "wix", allDeps[0].Name)
+
+	os.Args = os.Args[:len(os.Args)-3]
 }

--- a/cmd/notice-file-generator/testdata/dependency_test.yaml
+++ b/cmd/notice-file-generator/testdata/dependency_test.yaml
@@ -1,12 +1,10 @@
 ---
-
 title: "Notice Title"
 copyright: "Notice Copyright"
 description: "Notice Description"
 reviewers:
   - reviewerOne
-search:
-  - "package.json"
+search: []
 additionalDependencies:
   - wix
   - ignored

--- a/cmd/notice-file-generator/testdata/test.yaml
+++ b/cmd/notice-file-generator/testdata/test.yaml
@@ -1,5 +1,4 @@
 ---
-
 title: "Notice Title"
 copyright: "Notice Copyright"
 description: "Notice Description"


### PR DESCRIPTION
#### Summary

Context is here: https://hub.mattermost.com/private-core/pl/e3renij51jgdtdeaynsbzxn3uw

The mobile repository has organized part of its code as repository-local npm packages, which are mentioned in its `package.json`. This is an issue with the notice-file-generator, as it discovers them in `package.json` but then fails to query the npm registry for more infos about them.

This PR introduces the `ignoreDependencies` field which will let us ignore any package from both `go.mod` and `package.json`.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7943